### PR TITLE
Add hair prosthesis service details to homepage

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -21,6 +21,10 @@ export default function Hero() {
               mais incrível da cidade baixa
             </span>
           </h1>
+          <p className="text-lg md:text-xl text-gray-200 mb-6">
+            Agora com serviço de prótese capilar personalizada a partir de R$ 1.800,00 para recuperar sua
+            confiança com naturalidade.
+          </p>
           <Link href="https://wa.me/557192109189" target="_blank" rel="noopener noreferrer">
             <Button className="bg-gradient-to-r from-blue-500 to-blue-700 text-white border-0 px-8 py-6 text-lg hover:opacity-90 transition">
               Agende agora

--- a/components/sections/Services.tsx
+++ b/components/sections/Services.tsx
@@ -1,16 +1,40 @@
 "use client"
-import { Scissors, Palette, BeakerIcon as Beard, Sparkles, Droplets, Ruler, Package, Zap } from "lucide-react"
+import { ReactNode, useMemo } from "react"
+import {
+  Scissors,
+  Palette,
+  BeakerIcon as Beard,
+  Sparkles,
+  Droplets,
+  Ruler,
+  Package,
+  Zap,
+  Shield,
+} from "lucide-react"
 import { Card, CardContent } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Badge } from "@/components/ui/badge"
 
+type RegularService = {
+  title: string
+  description: string
+  icon: ReactNode
+} & ({
+  price: number
+  priceLabel?: never
+} | {
+  priceLabel: string
+  price?: never
+})
+
 export default function Services() {
-  const regularServices = [
-    {
-      title: "Corte de Cabelo",
-      description: "Cortes modernos e clássicos realizados com técnicas precisas.",
-      price: 25,
-      icon: <Scissors className="w-8 h-8" />,
+  const regularServices: RegularService[] = useMemo(
+    () => [
+      {
+        title: "Corte de Cabelo",
+        description: "Cortes modernos e clássicos realizados com técnicas precisas.",
+        price: 25,
+        icon: <Scissors className="w-8 h-8" />,
     },
     {
       title: "Barba",
@@ -42,13 +66,21 @@ export default function Services() {
       price: 70,
       icon: <Droplets className="w-8 h-8" />,
     },
-    {
-      title: "Descolorização",
-      description: "Processo para clarear os fios e preparar para coloração.",
-      price: 70,
-      icon: <Zap className="w-8 h-8" />,
-    },
-  ]
+      {
+        title: "Descolorização",
+        description: "Processo para clarear os fios e preparar para coloração.",
+        price: 70,
+        icon: <Zap className="w-8 h-8" />,
+      },
+      {
+        title: "Prótese Capilar",
+        description: "Restauração completa com próteses capilares de alto padrão sob medida.",
+        priceLabel: "A partir de R$ 1.800,00",
+        icon: <Shield className="w-8 h-8" />,
+      },
+    ],
+    [],
+  )
 
   const comboServices = [
     {
@@ -106,7 +138,9 @@ export default function Services() {
                       <p className="text-ddcece mb-4 flex-grow">{service.description}</p>
                       <div className="mt-auto">
                         <Badge className="bg-blue-600 hover:bg-blue-700 text-white text-lg py-1.5 px-4">
-                          R$ {service.price.toFixed(2).replace(".", ",")}
+                          {"price" in service
+                            ? `R$ ${service.price.toFixed(2).replace(".", ",")}`
+                            : service.priceLabel}
                         </Badge>
                       </div>
                     </CardContent>


### PR DESCRIPTION
## Summary
- highlight the new hair prosthesis offering on the hero section with pricing callout
- extend the services grid to support price labels and include the hair prosthesis card

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68da44f40cd4832db54b757f30b524dd