### PR TITLE
Fix accordion props type definition

### DIFF
--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -22,7 +22,7 @@ interface AccordionContextValue {
 const AccordionContext = createContext<AccordionContextValue | null>(null)
 const AccordionItemContext = createContext<string | null>(null)
 
-interface AccordionProps extends HTMLAttributes<HTMLDivElement> {
+interface AccordionProps extends Omit<HTMLAttributes<HTMLDivElement>, "defaultValue"> {
   type?: "single"
   collapsible?: boolean
   defaultValue?: string | null


### PR DESCRIPTION
## Summary
- adjust the accordion props interface to omit the conflicting defaultValue attribute

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dae0ebef8c832da1fb3a8f23b8c5e0